### PR TITLE
chore: rename 02-claude-usage to 02-usage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,7 +130,7 @@ tsumiki/
 ├── commands/               # コマンドテンプレート（.md, .sh）
 ├── dist/                  # ビルド出力
 ├── package.json
-├── CLAUDE.md              # プロジェクト指示書
+├── GEMINI.md              # プロジェクト指示書
 └── README.md
 ```
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,4 +1,4 @@
-# CLAUDE.md
+# GEMINI.md
 
 This file provides guidance to Gemini CLI when working with code in this repository.
 

--- a/book/02-environment/02-usage.md
+++ b/book/02-environment/02-usage.md
@@ -23,7 +23,7 @@ AITDDの核心となるgemini-2.5-proの効果的な活用方法について説�
 1. **Gemini CLIの起動**
    ```bash
    # VS Code内でGemini CLIを起動
-   # またはブラウザ版Claude経由でアクセス
+   # またはブラウザ版Gemini経由でアクセス
    ```
 
 2. **プロジェクトとの連携**
@@ -37,7 +37,7 @@ AITDDの核心となるgemini-2.5-proの効果的な活用方法について説�
 ```
 あなた: "ユーザー管理機能のCRUD操作を実装したい。まずTODOリストを作成してください。"
 
-Claude: "ユーザー管理機能のTODOリストを作成します：
+Gemini: "ユーザー管理機能のTODOリストを作成します：
 1. ユーザーモデルの定義
 2. ユーザー作成のテストケース作成
 3. ユーザー作成機能の実装
@@ -48,7 +48,7 @@ Claude: "ユーザー管理機能のTODOリストを作成します：
 ```
 あなた: "TODOの最初の項目のテストケースを作成してください。"
 
-Claude: "ユーザーモデルのテストケースを作成します：
+Gemini: "ユーザーモデルのテストケースを作成します：
 ```javascript
 describe('User Model', () => {
   test('should create user with valid data', () => {
@@ -62,7 +62,7 @@ describe('User Model', () => {
 ```
 あなた: "このテストを通すためのコードを実装してください。"
 
-Claude: "テストを通すためのユーザーモデルを実装します：
+Gemini: "テストを通すためのユーザーモデルを実装します：
 ```javascript
 class User {
   constructor(name, email) {

--- a/book/toc.md
+++ b/book/toc.md
@@ -10,7 +10,7 @@
 
 ### 第2章：開発環境とツールセットアップ
 - [2.1 必要なツールとセットアップ](./02-environment/01-tools-setup.md)
-- [2.2 gemini-2.5-proの活用方法](./02-environment/02-claude-usage.md)
+ - [2.2 gemini-2.5-proの活用方法](./02-environment/02-usage.md)
 - [2.3 開発環境とワークフロー構築](./02-environment/03-workflow-setup.md)
 
 ## 第2部：実践編


### PR DESCRIPTION
## Summary
- rename `02-claude-usage.md` to `02-usage.md`
- replace remaining Claude references with Gemini in the usage guide

## Testing
- `pnpm check`
- `pnpm typecheck`
- `pnpm secretlint`


------
https://chatgpt.com/codex/tasks/task_e_68aefdfc1010832f91a3366427487908