### PR TITLE
chore: update repository links

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,13 +10,13 @@
     "claudecode",
     "ai"
   ],
-  "homepage": "https://github.com/classmethod/tsumiki#readme",
+  "homepage": "https://github.com/R7038XX/tsumiki_gemini#readme",
   "bugs": {
-    "url": "https://github.com/classmethod/tsumiki/issues"
+    "url": "https://github.com/R7038XX/tsumiki_gemini/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/classmethod/tsumiki.git"
+    "url": "https://github.com/R7038XX/tsumiki_gemini.git"
   },
   "license": "MIT",
   "author": {


### PR DESCRIPTION
## Summary
- update project links to use R7038XX/tsumiki_gemini repository

## Testing
- `pnpm typecheck`
- `pnpm check`
- `pnpm fix`
- `pnpm secretlint`
- `pnpm build:run`


------
https://chatgpt.com/codex/tasks/task_e_68b04efdcb84832f9df4f6594b47c98b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated public links to point to the new GitHub repository, including the project homepage and issue tracker, ensuring users reach the correct documentation and support pages.
- Chores
  - Refreshed repository metadata to align with the new project location so source code and related references now direct to the correct repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->